### PR TITLE
Fixed group/create API doc

### DIFF
--- a/API-DOCS/GROUP.md
+++ b/API-DOCS/GROUP.md
@@ -135,10 +135,11 @@ axios.post('/group/info', {
 
 ```js
 axios.post('/group/create', {
-    token: '<Google OAuth Token>',
-    name: 'My Group', // Required
-    description: 'This is my group.', // Optional
-    members: ['<User 1 Email>', '<User 2 Email>'], // Optional
+    data:{
+        name: 'My Group', // Required
+        desc: 'This is my group.', // Optional
+        invites: ['<User 1 Email>', '<User 2 Email>'], // Optional
+    }
 }).then(function (response) {
     console.log(response);
 }).catch(function (error) {
@@ -150,9 +151,10 @@ axios.post('/group/create', {
 
 ```js
 axios.post('/group/create', {
-    token: '<Google OAuth Token>',
-    name: 'My Group', // Required
-    description: 'This is my group.', // Optional
+    data:{
+      name: 'My Group', // Required
+      desc: 'This is my group.', // Optional
+    }
 }).then(function (response) {
     console.log(response);
 }).catch(function (error) {

--- a/API-DOCS/USER.md
+++ b/API-DOCS/USER.md
@@ -243,8 +243,6 @@ axios.post('/user/update', {
 
 **Note**: This endpoint is only available to the current user
 
-**TODO Back-End**: Change `/person/delete` to `/user/delete`
-
 ### Request:
 
 | Field | Type   | Required | Default | Description        |


### PR DESCRIPTION
Fixed group/create API doc according to @PricklySaguaro's fix (removed token from request field, added data field, changed `description` to `desc`, and `members` to `invites`).