### PR TITLE
Hotfix: Delete Group in API Unit Tests

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -27,8 +27,9 @@ cd ~/Smart-Ledger/
 docker-compose up -d --build
 ```
 ### Login and Retrieve Token:
-Click 'API Client' under 'Other' on the left-hand side.
-Copy the Auth Token and paste in `token.txt`
+- Go to `localhost:3000` and log in with your Google account
+- Click 'API Client' under 'Other' on the left-hand side. (Click the hamburger in the top left if you don't see this option)
+- Copy the Auth Token and paste in `token.txt`
 
 ### Run Tests in New Shell
 ```shell

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -101,8 +101,7 @@ class Tests:
         # get the group
         content, status_code = self.do_post('/group/info', {'id': self.group['_id']['$oid']})
         assert status_code == 200
-        assert content['data']['name'] == 'test group update name'
-        assert content['data']['desc'] == 'test group update description'
+        assert content['data']['name'] == 'test group name'
 
         # delete the group
         content, status_code = self.do_post('/group/delete', {'id': self.group['_id']['$oid']})

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -98,6 +98,21 @@ class Tests:
         self.group = content['data']
         assert status_code == 200
 
+        # get the group
+        content, status_code = self.do_post('/group/info', {'id': self.group['_id']['$oid']})
+        assert status_code == 200
+        assert content['data']['name'] == 'test group update name'
+        assert content['data']['desc'] == 'test group update description'
+
+        # delete the group
+        content, status_code = self.do_post('/group/delete', {'id': self.group['_id']['$oid']})
+        assert status_code == 200
+
+        # check persons groups
+        content, status_code = self.do_post('/user/info', {'sub': self.user['data']['sub']})
+        assert status_code == 200
+        assert self.group['_id'] not in content['data']['groups']
+
     def test_bad_group(self):
         """
         test


### PR DESCRIPTION
Deleting Group in API Unit Test to prevent Database piling up.